### PR TITLE
Fix Formula style using `brew style --fix`

### DIFF
--- a/appicon.rb
+++ b/appicon.rb
@@ -1,17 +1,21 @@
+# typed: false
+# frozen_string_literal: true
+
+# AppIcon Homebrew Formula
 class Appicon < Formula
   desc "Generation of iOS AppIcon.appiconset made easy"
   homepage "https://github.com/Nonchalant/AppIcon"
   url "https://github.com/Nonchalant/AppIcon/archive/1.0.5.tar.gz"
   sha256 "dfd0239216ea6dcbf3ea99f599d144b6d8bf6e854d594e6ec93d34eaa8c28e09"
 
-  head 'https://github.com/Nonchalant/AppIcon.git', :branch => 'master'
-
-  depends_on :xcode => ["12", :build]
+  head "https://github.com/Nonchalant/AppIcon.git", branch: "master"
 
   bottle do
     root_url "https://github.com/Nonchalant/AppIcon/releases/download/1.0.5"
-    sha256 "ccf261cf9206410bc1adf77996bc3c4461d3199de75e65193e755504f98cfb6e" => :catalina
+    sha256 catalina: "ccf261cf9206410bc1adf77996bc3c4461d3199de75e65193e755504f98cfb6e"
   end
+
+  depends_on xcode: ["12", :build]
 
   def install
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
Formula was throwing deprecation warning:

_Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead._

on install with latest Homebrew version. 

Fixed by running `brew style --fix` on the Formula.